### PR TITLE
feat: implement Postgres guild repository

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,6 +874,7 @@ dependencies = [
  "serde",
  "sqlx",
  "thiserror",
+ "tracing",
  "uuid",
 ]
 

--- a/services/guild-service/core/.sqlx/query-329b143fd25804338637c555e0a6b624e6d3986e4ba20f1e350496091f87d8c5.json
+++ b/services/guild-service/core/.sqlx/query-329b143fd25804338637c555e0a6b624e6d3986e4ba20f1e350496091f87d8c5.json
@@ -1,0 +1,46 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, name, slug, owner_id, created_at FROM guilds WHERE owner_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "slug",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "owner_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 4,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "329b143fd25804338637c555e0a6b624e6d3986e4ba20f1e350496091f87d8c5"
+}

--- a/services/guild-service/core/.sqlx/query-3a9581068e2ed681049588e7383ea34e3a73962af04ad8f082ca5033cb3eb881.json
+++ b/services/guild-service/core/.sqlx/query-3a9581068e2ed681049588e7383ea34e3a73962af04ad8f082ca5033cb3eb881.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO guilds (id, name, slug, owner_id, created_at)\n            VALUES ($1, $2, $3, $4, $5)\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text",
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "3a9581068e2ed681049588e7383ea34e3a73962af04ad8f082ca5033cb3eb881"
+}

--- a/services/guild-service/core/.sqlx/query-b27adda40e60995957ebeb96d86a493fb937db313120d272a5a5b1bc58d780fd.json
+++ b/services/guild-service/core/.sqlx/query-b27adda40e60995957ebeb96d86a493fb937db313120d272a5a5b1bc58d780fd.json
@@ -1,0 +1,46 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, name, slug, owner_id, created_at FROM guilds WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "slug",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "owner_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 4,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "b27adda40e60995957ebeb96d86a493fb937db313120d272a5a5b1bc58d780fd"
+}

--- a/services/guild-service/core/Cargo.toml
+++ b/services/guild-service/core/Cargo.toml
@@ -14,6 +14,7 @@ ferriscord-auth = { path = "../../../libs/auth" }
 ferriscord-config = { path = "../../../libs/config" }
 chrono = { version = "0.4.42", features = ["serde"] }
 serde = { version = "1.0.226", features = ["derive"] }
-sqlx = { version = "0.8.6", features = ["postgres", "runtime-tokio"] }
+sqlx = { version = "0.8.6", features = ["chrono", "postgres", "runtime-tokio", "uuid"] }
 thiserror = "2.0.16"
-uuid = { version = "1.18.1", features = ["v7"] }
+uuid = { version = "1.18.1", features = ["serde", "v7"] }
+tracing = "0.1.41"

--- a/services/guild-service/core/src/domain/errors.rs
+++ b/services/guild-service/core/src/domain/errors.rs
@@ -10,9 +10,15 @@ pub enum CoreError {
     #[error("guild with id {guild_id} already exists")]
     GuildAlreadyExists { guild_id: GuildId },
 
+    #[error("guild slug '{slug}' already exists")]
+    GuildSlugAlreadyExists { slug: String },
+
     #[error("maximum number of guilds reached: {max_guilds}")]
     MaxGuildsReached { max_guilds: usize },
 
     #[error("infrastructure database setup error: {details}")]
     InfrastructureDatabaseSetupError { details: String },
+
+    #[error("unknown error: {message}")]
+    Unknown { message: String },
 }

--- a/services/guild-service/core/src/domain/guild/entities.rs
+++ b/services/guild-service/core/src/domain/guild/entities.rs
@@ -8,6 +8,12 @@ use crate::domain::Id;
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct GuildId(pub Id);
 
+impl GuildId {
+    pub fn get_uuid(&self) -> &uuid::Uuid {
+        &self.0.0
+    }
+}
+
 impl Display for GuildId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
@@ -16,6 +22,12 @@ impl Display for GuildId {
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct OwnerId(pub Id);
+
+impl OwnerId {
+    pub fn get_uuid(&self) -> &uuid::Uuid {
+        &self.0.0
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct Guild {

--- a/services/guild-service/core/src/domain/mod.rs
+++ b/services/guild-service/core/src/domain/mod.rs
@@ -28,6 +28,10 @@ impl Id {
 
         Self(Uuid::new_v7(timestamp))
     }
+
+    pub fn get_uuid(&self) -> Uuid {
+        self.0
+    }
 }
 
 impl Default for Id {

--- a/services/guild-service/core/src/infrastructure/guild/postgres.rs
+++ b/services/guild-service/core/src/infrastructure/guild/postgres.rs
@@ -1,6 +1,10 @@
-use sqlx::PgPool;
+use chrono::{DateTime, Utc};
+use sqlx::{PgPool, query, query_as};
+use tracing::{debug, error};
+use uuid::Uuid;
 
 use crate::domain::{
+    Id,
     errors::CoreError,
     guild::{
         entities::{CreateGuildInput, Guild, GuildId, OwnerId},
@@ -19,17 +23,95 @@ impl PostgresGuildRepository {
         Self { pool }
     }
 }
+#[derive(sqlx::FromRow)]
+struct GuildRow {
+    id: Uuid,
+    name: String,
+    slug: String,
+    owner_id: Uuid,
+    created_at: DateTime<Utc>,
+}
+
+impl From<GuildRow> for Guild {
+    fn from(row: GuildRow) -> Self {
+        Guild {
+            id: GuildId(Id(row.id)),
+            name: row.name,
+            slug: row.slug,
+            owner_id: OwnerId(Id(row.owner_id)),
+            created_at: row.created_at,
+        }
+    }
+}
 
 impl GuildPort for PostgresGuildRepository {
-    async fn find_by_id(&self, _id: &GuildId) -> Result<Option<Guild>, CoreError> {
-        todo!()
+    async fn find_by_id(&self, id: &GuildId) -> Result<Option<Guild>, CoreError> {
+        debug!("finding guild by id: {}", id);
+
+        let row = query_as!(
+            GuildRow,
+            "SELECT id, name, slug, owner_id, created_at FROM guilds WHERE id = $1",
+            id.get_uuid()
+        )
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|_| CoreError::GuildNotFound {
+            guild_id: id.clone(),
+        })?;
+
+        Ok(row.map(Guild::from))
     }
 
-    async fn insert(&self, _input: CreateGuildInput) -> Result<Guild, CoreError> {
-        todo!()
+    async fn insert(&self, input: CreateGuildInput) -> Result<Guild, CoreError> {
+        let guild = Guild::new(input.name.clone(), input.owner_id);
+
+        query!(
+            r#"
+            INSERT INTO guilds (id, name, slug, owner_id, created_at)
+            VALUES ($1, $2, $3, $4, $5)
+            "#,
+            guild.id.get_uuid(),
+            guild.name,
+            guild.slug,
+            guild.owner_id.get_uuid(),
+            guild.created_at,
+        )
+        .execute(&self.pool)
+        .await
+        .map_err(|e| {
+            error!("failed to insert guild: {}", e);
+
+            if let Some(db_err) = e.as_database_error() {
+                if db_err.constraint() == Some("guilds_slug_key") {
+                    return CoreError::GuildSlugAlreadyExists { slug: input.name };
+                }
+            }
+
+            CoreError::Unknown {
+                message: e.to_string(),
+            }
+        })?;
+
+        Ok(guild)
     }
 
-    async fn list_by_owner(&self, _owner_id: &OwnerId) -> Result<Vec<Guild>, CoreError> {
-        todo!()
+    async fn list_by_owner(&self, owner_id: &OwnerId) -> Result<Vec<Guild>, CoreError> {
+        let rows = query_as!(
+            GuildRow,
+            "SELECT id, name, slug, owner_id, created_at FROM guilds WHERE owner_id = $1",
+            owner_id.get_uuid()
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to list guilds for owner {}: {}", owner_id.0, e);
+            CoreError::Unknown {
+                message: format!("Failed to list guilds by owner: {}", e),
+            }
+        })?;
+
+        let guilds: Vec<Guild> = rows.into_iter().map(Guild::from).collect();
+
+        Ok(guilds)
     }
 }


### PR DESCRIPTION
Add SQLx query files and implement find_by_id, insert, and list_by_owner with GuildRow mapping. Add UUID helper methods, new error variants and tracing. Map unique slug DB constraint to GuildSlugAlreadyExists and convert other DB errors to Unknown with logging.